### PR TITLE
Fix license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,6 @@
 
 Copyright © [2023] [raemenn jewall]
 
-All Rights Reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ To embark on this voyage and see the wonders me code can conjure, follow these s
 
 4. **Explore the Web Apps**:
     Each web app resides in its own directory. Dive into the code, make tweaks, and witness the changes on the high seas of the internet.
+## License 📝
+
+This project be shared under the [MIT License](LICENSE). Keep the notice in yer sails as ye set forth.
 
 
 **Cap'n raemenn**  


### PR DESCRIPTION
## Summary
- remove "All Rights Reserved" from LICENSE
- cite MIT license in README

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d0a26c32c8327b25bd73553b9cafe