### PR TITLE
Add hamburger menu to moon page

### DIFF
--- a/moon_advice.html
+++ b/moon_advice.html
@@ -12,6 +12,7 @@ svg{position:absolute;top:0;left:0;width:100%;height:100%;z-index:-1;}
 </style>
 </head>
 <body>
+<iframe src="/hamburger_menu.html" style="border:none;width:60px;height:60px;position:fixed;top:10px;left:10px;z-index:1000;"></iframe>
 <svg viewBox="0 0 100 100" preserveAspectRatio="xMidYMid slice">
     <defs>
         <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">


### PR DESCRIPTION
## Summary
- add hamburger menu iframe to moon_advice.html for navigation

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684f50b7774c8327ab89e60764a85f0e