### PR TITLE
Reduce debounce delay in tapemeasurememory.html

### DIFF
--- a/tapemeasurememory.html
+++ b/tapemeasurememory.html
@@ -543,7 +543,7 @@
               centerLine.classList.add('hidden');
               console.log('Calculation failed or incomplete');
             }
-          }, 500);
+          }, 200);
 
         });
       });
@@ -637,7 +637,7 @@
               decimalResultDisplay.textContent = '';
               centerLine.classList.add('hidden');
             }
-          }, 500);
+          }, 200);
         });
       });
 


### PR DESCRIPTION
## Summary
- Decrease debounce delay for evaluation to 200ms in `tapemeasurememory.html` to speed up UI updates.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fb55e3448327a734517f73a0a17e